### PR TITLE
Resolving the issue with the application failing to start

### DIFF
--- a/lib/unlock_panel/unlock_panel_viewmodel.dart
+++ b/lib/unlock_panel/unlock_panel_viewmodel.dart
@@ -37,10 +37,15 @@ class UnlockPanelViewModel extends PageViewModel {
         break;
       case DeviceLockType.none:
         // ignore: use_build_context_synchronously
-        router.changePage(
-          "/setup-lock",
-          pageContext,
-          TransitionData(next: PageTransition.slideForward),
+        Future.delayed(
+          const Duration(milliseconds: 500),
+          () {
+            router.changePage(
+              "/setup-lock",
+              pageContext,
+              TransitionData(next: PageTransition.slideForward),
+            );
+          },
         );
         break;
     }


### PR DESCRIPTION
Newer devices having a faster processing power, sometimes load before all the dependencies are being registered, due to that emulators ran fine as they generally take their time before rendering the page. 

This lead to this bug where the unlock page would load faster than the dependencies causing the application to error out before the page router is registered when it attempts to change the page to the initial setup page. 

As the default behavior is that if a lock screen has been enabled, but at the same time the installation wasn't finished, and the app got terminated we route the page back to the setup page to chose an option. 
